### PR TITLE
Fixed container name in run_oracle_sqlplus.sh

### DIFF
--- a/commands/run_oracle_sqlplus.sh
+++ b/commands/run_oracle_sqlplus.sh
@@ -1,3 +1,3 @@
-docker start oracle-23ai
+docker start oracle-23-ai
 
-docker exec -it oracle-23ai bash -c "sqlplus / as sysdba"
+docker exec -it oracle-23-ai bash -c "sqlplus / as sysdba"


### PR DESCRIPTION
Updated container name to align with run_oracle_23ai.sh

# Description

The script `run_oracle_sqlplus.sh` does not work to attach to the container created by `run_oracle_23ai.sh` due to the typo in container name

Fixes # (link to issue if possible)

## Changes

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:
